### PR TITLE
Store Transcript in Local Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ A chrome extension for searching video transcript content and navigate to any li
 ## Screenshot
 <img src="docs/popup-result.png" />
 
-## Hot to Run
+# How to Run
 This project depends on [video-content-miner-server](https://github.com/twuoy/video-content-miner-server) project, please clone and start the server if you want to run this extension.
 
 ## Build
-Run following command to build the extension. The default API url is `http://localhost:50000/api`, you can change it by passing env variable `API_URL`.
+Run the following command to build the extension.
+Note that the default `video-content-miner-server` API url is `http://localhost:50000/api`, you can change it by passing env variable `API_URL`.
 
 ```shell
 yarn install
@@ -24,10 +25,10 @@ yarn build --env API_URL={YOUR_API_URL}
 ## Load an unpacked extension
 1. After build step you will find a `dist` directory in project root.
 2. Navigate to `chrome://extensions`.
-3. Click the Load unpacked button and select the `dist` extension directory.
+3. Click the `Load unpacked button` and select the `dist` extension directory.
 - You can find detailed steps in [this Google document](https://developer.chrome.com/docs/extensions/mv3/getstarted/#unpacked).
 
-## How to Use
+# How to Use
 - Go to the youtube video you want to search.
 - Click the extension icon at the top-right corner of the browser.
 - Enter your keyword and click `Mine`.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,19 +11,21 @@
       "256": "images/icon256.png"
     }
   },
+  "host_permissions": ["https://*.youtube.com/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"
   },
   "content_scripts": [
     {
-      "matches":["https://www.youtube.com/watch?v=*"],
+      "matches":["https://*.youtube.com/*"],
       "js": ["content.js"]
     }
   ],
   "permissions": [
     "activeTab",
     "declarativeContent",
+    "storage",
     "tabs"
   ],
   "icons": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,10 @@ try {
     });
   });
 
+  chrome.runtime.onStartup.addListener(function() {
+    chrome.storage.sync.clear();
+  });
+
 } catch (e) {
   console.error(`backgroung page exception: ${e}`);
 }

--- a/src/components/Popup/Transcript.tsx
+++ b/src/components/Popup/Transcript.tsx
@@ -29,7 +29,7 @@ const Transcript: FC<TranscriptProps> = (props) => {
       <Timeline color="cyan" radius="md" active={selectedTimeIndex}>
         {
           transcript.map((lineInfo, index) => (
-            <Timeline.Item title={`${Math.floor(lineInfo.start)}s`}>
+            <Timeline.Item key={index} title={`${Math.floor(lineInfo.start)}s`}>
               <TranscriptLine key={index} timeLineIndex={index} lineInfo={lineInfo} updateVideoTime={updateVideoTime}/>
               <Divider size="sm"></Divider>
             </Timeline.Item>


### PR DESCRIPTION
Store transcript for the specified video when user visiting the video for the first time, and get transcript from storage before fetching from server to avoid getting transcript from server every time.

## Todos
- [x] Store transcript for the specified video when user visiting the video for the first time.
- [x] Clear all the transcripts when a profile that has this extension installed first starts up. (close chrome and start again).

## Note
- The data format in local storage is `{ [videoID]: transcript }`.